### PR TITLE
Possible Fix for Issue# 29

### DIFF
--- a/src/BaseVisitor.ts
+++ b/src/BaseVisitor.ts
@@ -39,18 +39,16 @@ export class BaseVisitor extends Visitor {
   }
 
   protected mergeTrailing(elements: ASTNode[] = [], trailing: ASTNode[] = []): ASTNode[] {
-    const linedElements = this.byLine(elements)
     const linedTrailing = this.byLine(trailing)
-
-    const merger = (el: ASTNode, line: number): ASTNode => {
+    const merger = (el: ASTNode): ASTNode => {
+      const line = el.loc && el.loc.start.line
       if (linedTrailing[line]) {
         el.trailing = linedTrailing[line]
       }
-
       return el
     }
 
-    return map<ASTNode>(linedElements, merger) as any
+    return map<ASTNode>(elements, merger) as any
   }
 
   protected Location(head: ASTNode, tail: ASTNode): Location {


### PR DESCRIPTION
Possible fix for https://github.com/RokuRoad/bright/issues/29 where we attempt to keep the comment information but remove the issue where multiple tokens on the same line are lost.

